### PR TITLE
fix: error message of failed tasks is returned when timeout is set

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -2,10 +2,16 @@ export function timeout(promise, millis) {
   return new Promise((resolve, reject) => {
     const timeoutId = setTimeout(() => reject(new Error('operation timed out')), millis);
 
-    promise.then(result => {
-      clearTimeout(timeoutId);
-      resolve(result);
-    });
+    promise.then(
+      result => {
+        clearTimeout(timeoutId);
+        resolve(result);
+      },
+      error => {
+        clearTimeout(timeoutId);
+        reject(error);
+      }
+    );
   });
 }
 

--- a/src/spec/promise-poller-spec.js
+++ b/src/spec/promise-poller-spec.js
@@ -268,6 +268,23 @@ describe('Promise Poller', () => {
     });
   });
 
+  it('rejects with correct error message when task fails and timeout is set', done => {
+    const errorMessage = 'operation failed';
+    const taskFn = () => {
+      return Promise.reject(errorMessage);
+    };
+
+    promisePoller({
+      taskFn,
+      interval: 10,
+      retries: 2,
+      timeout: 10
+    }).then(fail, err => {
+      expect(err).toEqual([errorMessage, errorMessage]);
+      done();
+    });
+  });
+
   it('bails out when shouldContinue returns false', done => {
     let counter = 0;
     const taskFn = () => Promise.reject(++counter);


### PR DESCRIPTION
The error message of a failed task is propagated to the main promise when a timeout was defined.